### PR TITLE
fix: embed timeout value with quotation marks

### DIFF
--- a/submodules/runner/config.toml
+++ b/submodules/runner/config.toml
@@ -33,7 +33,7 @@
       use_external_addr      = false
       use_static_credentials = true
       key_path               = "/root/.ssh/id_rsa"
-      timeout                = ${SSH_TIMEOUT}
+      timeout                = "${SSH_TIMEOUT}"
 
     [[runners.autoscaler.policy]]
       idle_count = ${IDLE_COUNT}


### PR DESCRIPTION
Fix issue where the config.toml file would be improperly formatted