### PR TITLE
fix: add option to disable vm integrity monitoring

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ module "runner" {
   name                   = each.value.name
   ssh_connection_timeout = "${try(coalesce(tonumber(each.value.ssh_connection_timeout), 10), 10)}m"
   token                  = each.value.token
+  enable_integrity_monitoring = each.value.enable_integrity_monitoring
   vm_type                = each.value.vm_type
 
   allow_cloud_console_ssh = var.allow_cloud_console_ssh

--- a/submodules/runner/pool.tf
+++ b/submodules/runner/pool.tf
@@ -69,7 +69,7 @@ resource "google_compute_instance_template" "job_runner_template" {
   shielded_instance_config {
     enable_secure_boot          = true
     enable_vtpm                 = true
-    enable_integrity_monitoring = true
+    enable_integrity_monitoring = var.enable_integrity_monitoring
   }
 
   scheduling {

--- a/submodules/runner/variables.tf
+++ b/submodules/runner/variables.tf
@@ -35,6 +35,12 @@ variable "enable_display" {
   type        = bool
 }
 
+variable "enable_integrity_monitoring" {
+  description = "Enable integrity monitoring for the runner"
+  default     = true
+  type        = bool
+}
+
 variable "gitlab_url" {
   description = "The URL of the GitLab instance to register with"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,8 @@ variable "runners" {
     disk_size_gb = number
     # Enable display functionality for the runner (default: false)
     enable_display = optional(bool, false)
+    # Enable integrity monitoring for the runner (default: true) See also: https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring
+    enable_integrity_monitoring = optional(bool, true)
     # The number of instances to keep on standby
     idle_count = number
     # The number of minutes to wait while connecting to an instance via SSH


### PR DESCRIPTION
Add an option (`enable_integrity_monitoring`) to enable/disable the [VM integrity monitoring](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring) option on the instance template. This option can be specified for individual runner definitions.

The new option defaults to being enabled, which is the same behavior as in past versions of the module.