### PR TITLE
fix: do not disable project services on terraform destroy

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.3"
   constraints = "2.3.3"
   hashes = [
+    "h1:GmJ8PxLjjPr+lh02Bw3u7RYqA3UtpE2hQ1T43Vt7PTQ=",
     "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
     "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
     "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",

--- a/enabled-services.tf
+++ b/enabled-services.tf
@@ -1,33 +1,39 @@
 resource "google_project_service" "compute-engine" {
-  project = var.host_project
-  service = "compute.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "compute.googleapis.com"
 
   depends_on = [google_project_service.os-login]
 }
 
 resource "google_project_service" "iam-credentials" {
-  project = var.host_project
-  service = "iamcredentials.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "iamcredentials.googleapis.com"
 }
 
 resource "google_project_service" "logging" {
-  project = var.host_project
-  service = "logging.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "logging.googleapis.com"
 }
 
 resource "google_project_service" "monitoring" {
-  project = var.host_project
-  service = "monitoring.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "monitoring.googleapis.com"
 }
 
 resource "google_project_service" "network-management" {
-  project = var.host_project
-  service = "networkmanagement.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "networkmanagement.googleapis.com"
 }
 
 resource "google_project_service" "os-config" {
-  project = var.host_project
-  service = "osconfig.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "osconfig.googleapis.com"
 
   depends_on = [
     google_project_service.os-login,
@@ -36,21 +42,25 @@ resource "google_project_service" "os-config" {
 }
 
 resource "google_project_service" "os-login" {
-  project = var.host_project
-  service = "oslogin.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "oslogin.googleapis.com"
 }
 
 resource "google_project_service" "service-usage" {
-  project = var.host_project
-  service = "serviceusage.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "serviceusage.googleapis.com"
 }
 
 resource "google_project_service" "storage" {
-  project = var.host_project
-  service = "storage.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "storage.googleapis.com"
 }
 
 resource "google_project_service" "storage-component" {
-  project = var.host_project
-  service = "storage-component.googleapis.com"
+  disable_on_destroy = false
+  project            = var.host_project
+  service            = "storage-component.googleapis.com"
 }


### PR DESCRIPTION
This change facilitates automated destroy/deploy operations to create clean runners