### PR TITLE
Pin GitLab Runner version to resolve SSH issue

### DIFF
--- a/submodules/manager/init.sh
+++ b/submodules/manager/init.sh
@@ -9,6 +9,7 @@ echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 
 # Download static private key
 curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/ssh-key-to-use -H 'Metadata-Flavor: Google' -o /root/.ssh/id_rsa
+sudo chmod 600 /root/.ssh/id_rsa
 
 # Install Docker
 sudo apt-get update

--- a/submodules/manager/manager-start-command.sh
+++ b/submodules/manager/manager-start-command.sh
@@ -10,7 +10,7 @@ sudo docker run \
     -e FLEETING_PLUGIN_PATH="/usr/local/bin" \
     --privileged \
     --network host \
-    gitlab/gitlab-runner:latest \
+    gitlab/gitlab-runner:ubuntu-92594782 \
     fleeting install && \
     # We want to install the fleeting plugin for the system before we run the system itself
 
@@ -26,6 +26,6 @@ sudo docker run -d --name gitlab-runner --restart always \
     -e FLEETING_PLUGIN_PATH="/usr/local/bin" \
     --privileged \
     --network host \
-    gitlab/gitlab-runner:latest \
+    gitlab/gitlab-runner:ubuntu-92594782 \
     run --working-directory=/home/gitlab-runner --user=root
     # This last line ^^ is for the runner system to start within the docker containerd


### PR DESCRIPTION
- Pin runner version to v17.11.0 prerelease to resolve SSH issue
- Restrict access to enable manual SSH connections from manager VM (bug found during troubleshooting)

Closes #11 