### PR TITLE
chore: update runner to v18.3.1

### DIFF
--- a/submodules/manager/manager-start-command.sh
+++ b/submodules/manager/manager-start-command.sh
@@ -10,7 +10,7 @@ sudo docker run \
     -e FLEETING_PLUGIN_PATH="/usr/local/bin" \
     --privileged \
     --network host \
-    gitlab/gitlab-runner:ubuntu-92594782 \
+    gitlab/gitlab-runner:ubuntu-v18.1.1 \
     fleeting install && \
     # We want to install the fleeting plugin for the system before we run the system itself
 
@@ -26,6 +26,6 @@ sudo docker run -d --name gitlab-runner --restart always \
     -e FLEETING_PLUGIN_PATH="/usr/local/bin" \
     --privileged \
     --network host \
-    gitlab/gitlab-runner:ubuntu-92594782 \
+    gitlab/gitlab-runner:ubuntu-v18.1.1 \
     run --working-directory=/home/gitlab-runner --user=root
     # This last line ^^ is for the runner system to start within the docker containerd

--- a/submodules/manager/manager-start-command.sh
+++ b/submodules/manager/manager-start-command.sh
@@ -10,7 +10,7 @@ sudo docker run \
     -e FLEETING_PLUGIN_PATH="/usr/local/bin" \
     --privileged \
     --network host \
-    gitlab/gitlab-runner:ubuntu-v18.1.1 \
+    gitlab/gitlab-runner:ubuntu-v18.3.1 \
     fleeting install && \
     # We want to install the fleeting plugin for the system before we run the system itself
 
@@ -26,6 +26,6 @@ sudo docker run -d --name gitlab-runner --restart always \
     -e FLEETING_PLUGIN_PATH="/usr/local/bin" \
     --privileged \
     --network host \
-    gitlab/gitlab-runner:ubuntu-v18.1.1 \
+    gitlab/gitlab-runner:ubuntu-v18.3.1 \
     run --working-directory=/home/gitlab-runner --user=root
     # This last line ^^ is for the runner system to start within the docker containerd


### PR DESCRIPTION
Update the gitlab runner version to 18.1.1 to get the latest features; I've been testing this personally for the past month or so and it seems stable.

Note that this update follows the version being pinned in #12. The underlying ssh error that necessitated that revert appears to have been fixed by Gitlab at some point since then.

Closes #13. 